### PR TITLE
ci: adapt the container build workflow to the forked repo and remove amd64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
       - 'docker-build'
 
 env:
-  IMAGE_NAME: ghcr.io/SpiderVice/docker-warproxy
+  IMAGE_NAME: ghcr.io/spidervice/docker-warproxy
 
 jobs:
   buildx:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
-name: buildx-testbranch
+name: buildx
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - 'docker-build'
+      - 'main'
 
 env:
   IMAGE_NAME: ghcr.io/spidervice/docker-warproxy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - 'docker-build'
 
 env:
-  IMAGE_NAME: ghcr.io/105pm/docker-warproxy
+  IMAGE_NAME: ghcr.io/SpiderVice/docker-warproxy
 
 jobs:
   buildx:
@@ -49,7 +49,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - 
         name: Buildx and Push
         uses: docker/build-push-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: buildx
+name: buildx-testbranch
 
 on:
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,13 +29,13 @@ jobs:
           context: .
           file: Dockerfile
           tags: ${{ env.IMAGE_NAME }}:testing
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
       - 
         name: Load Built Image and Test
         run: |
           docker buildx build \
             -t ${{ env.IMAGE_NAME }}:testing \
-            --platform=linux/amd64 \
+            --platform=linux/arm64 \
             --load \
             .
           CID=$(docker run -d ${{ env.IMAGE_NAME }}:testing)
@@ -58,5 +58,5 @@ jobs:
           file: Dockerfile
           tags: |
             ${{ env.IMAGE_NAME }}:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore vscode configs
+.vscode/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ COPY --from=collector /bar/ /
 ENV \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     PYTHONUNBUFFERED=1 \
-    TZ=Asia/Seoul \
+    TZ=Europe/London \
     PROXY_ENABLED=true \
     PROXY_PORT=8008
 


### PR DESCRIPTION
Because the original repo isn't updated often, I'm building my own to keep the dependent services/containers up to date (also an attempt to debug something I suspected was due to a change in one of the dependencies). 
To be able to use the existing GitHub Action in the fork, it needed to be adjusted to the new repository so the resulting container can be published onto the Registry.

This is to be used on an arm64 device, so cut off on build time (half!) by removing the amd64 build target.